### PR TITLE
getTagFromURL: pass url to getSingleURL()

### DIFF
--- a/lowLag.js
+++ b/lowLag.js
@@ -131,7 +131,7 @@ var lowLag = new function(){
 //or the first url 
 	this.getTagFromURL = function(url,tag){
 		if(tag != undefined) return tag;
-		return lowLag.getSingleURL();
+		return lowLag.getSingleURL(url);
 	}
 	this.getSingleURL = function(urls){
 		if(typeof(urls) == "string") return urls;


### PR DESCRIPTION
url was not being passed to getSingleURL(). This was causing a
"TypeError: Cannot read property '0' of undefined" when attempting to
index urls[0]. This would occur when the user used the shorthand form of
lowLag.load(url) rather than the lowLag.load(url, tag) form.
