### PR TITLE
update method name to start webkit sounds

### DIFF
--- a/lowLag.js
+++ b/lowLag.js
@@ -188,7 +188,7 @@ lowLag.msg('webkitAudio loading '+url+' as tag ' + tag);
 		var source = context.createBufferSource(); // creates a sound source
 		source.buffer = buffer;                    // tell the source which sound to play
 		source.connect(context.destination);       // connect the source to the context's destination (the speakers)
-		source.noteOn(0);                          // play the source now
+		source.start(0);                          // play the source now
 	}
 
 


### PR DESCRIPTION
Fix critical bug causing JS error in newest Chrome.

Chrome v.36 no longer supports the `noteOn` method, so replace it with
the newer `start` method.
See following reference:

https://code.google.com/p/chromium/issues/detail?id=358398

https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Porting_w
ebkitAudioContext_code_to_standards_based_AudioContext#Changes_to_method
s_used_to_start.2Fstop_AudioBufferSourceNode_and_OscillatorNode
