### PR TITLE
Chrome 36 compatibility shim

### DIFF
--- a/lowLag.js
+++ b/lowLag.js
@@ -188,7 +188,11 @@ lowLag.msg('webkitAudio loading '+url+' as tag ' + tag);
 		var source = context.createBufferSource(); // creates a sound source
 		source.buffer = buffer;                    // tell the source which sound to play
 		source.connect(context.destination);       // connect the source to the context's destination (the speakers)
-		source.noteOn(0);                          // play the source now
+		if (typeof(source.noteOn) == "function") {
+			source.noteOn(0);                          // play the source now, using noteOn
+		} else {
+			source.start();				// play the source now, using start
+		}
 	}
 
 


### PR DESCRIPTION
So - Chrome 36 doesn't support noteOn. This should detect the lack of noteOn support and fire a start() instead.
