### PR TITLE
reuse existing audioContext

### DIFF
--- a/lowLag.js
+++ b/lowLag.js
@@ -105,7 +105,8 @@ var lowLag = new function(){
 				this.msg("init audioContext");
 				this.load= this.loadSoundAudioContext;
 				this.play = this.playSoundAudioContext;
-				this.audioContext = new(window.AudioContext || window.webkitAudioContext)();
+				if(!this.audioContext)
+					this.audioContext = new(window.AudioContext || window.webkitAudioContext)();
 				if (this.useSuspension &= ('suspend' in lowLag.audioContext && 'onended' in lowLag.audioContext.createBufferSource())) {
 					this.playingQueue = [];
 					this.suspendPlaybackAudioContext();


### PR DESCRIPTION
if this.audioContext already exists (say if init gets called more than once), making a new one may fail.  If there is an existing this.audioContext, use the existing one.